### PR TITLE
bugfix for crispy_form invalid filter

### DIFF
--- a/doghub/settings.py
+++ b/doghub/settings.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-
+CRISPY_TEMPLATE_PACK = 'bootstrap5'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "crispy_forms",
+    "crispy_bootstrap5",
 ]
 
 MIDDLEWARE = [

--- a/doghub_app/templates/doghub_app/register.html
+++ b/doghub_app/templates/doghub_app/register.html
@@ -1,5 +1,5 @@
 {% extends "doghub_app/header.html" %} {% block content %}
-
+{% load crispy_forms_tags %}
 <!--Register-->
 {% if messages %} {% for message in messages %}
 <div class="alert alert-{{ message.tags }}">{{ message }}</div>
@@ -7,7 +7,7 @@
 <div class="container py-5">
   <h1>Register</h1>
   <form method="POST">
-    {% csrf_token %} {{ register_form }}
+    {% csrf_token %} {{ register_form | crispy }}
     <button class="btn btn-primary" type="submit">Register</button>
   </form>
   <p class="text-center">


### PR DESCRIPTION
bugfix for crispy form
you'll still need to install bootstrap5
you can customize the template_pack in settings with other options, see here:
https://django-crispy-forms.readthedocs.io/en/latest/install.html
